### PR TITLE
Add .NET dependencies check to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,4 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-  
+
+  - package-ecosystem: "nuget"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Currently nuget dependencies are old. Waiting to merge when bot will be rewritten in v3